### PR TITLE
server.List実装

### DIFF
--- a/server/invoice_test.go
+++ b/server/invoice_test.go
@@ -58,6 +58,7 @@ func TestCreateInvoice(t *testing.T) {
 					TaxRate:           0.10,
 					BillingAmount:     10440,
 					PaymentDate:       time.Date(2024, 4, 5, 0, 0, 0, 0, time.UTC),
+					Status:            models.InvoiceStatusUnprocessed,
 				}, nil)
 			},
 			want: want{
@@ -73,6 +74,7 @@ func TestCreateInvoice(t *testing.T) {
 					TaxRate:           0.10,
 					BillingAmount:     10440,
 					PaymentDate:       time.Date(2024, 4, 5, 0, 0, 0, 0, time.UTC),
+					Status:            string(models.InvoiceStatusUnprocessed),
 				},
 			},
 		},
@@ -86,6 +88,143 @@ func TestCreateInvoice(t *testing.T) {
 			tt.setup(mockInvoiceUsecase)
 			server := server.NewServer(mockInvoiceUsecase, &server.ServerConfig{})
 			res, err := server.CreateInvoice(tt.args)
+			if err != nil {
+				assert.Equal(t, tt.want.err, err)
+			}
+			assert.Equal(t, tt.want.res, res)
+		})
+	}
+}
+
+func TestListInvoice(t *testing.T) {
+	type want struct {
+		res []*server.InvoiceResponse
+		err error
+	}
+
+	tests := []struct {
+		description string
+		args        *gin.Context
+		setup       func(mockInvoiceUsecase *mock_usecase.MockInvoiceUsecase)
+		want        want
+	}{
+		{
+			description: "正常系",
+			args: func() *gin.Context {
+				ginContext, _ := gin.CreateTestContext(httptest.NewRecorder())
+				body := bytes.NewBufferString("{\"company_guid\": \"company_guid\",\"first_payment_date\": \"2024-04-01T00:00:00Z\",\"last_payment_date\": \"2024-04-05T00:00:00Z\"}")
+				req, _ := http.NewRequest("GET", "/api/invoices", body)
+				ginContext.Request = req
+				return ginContext
+			}(),
+			setup: func(mockInvoiceUsecase *mock_usecase.MockInvoiceUsecase) {
+				mockInvoiceUsecase.EXPECT().List(
+					gomock.Any(),
+					"company_guid",
+					time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2024, 4, 5, 0, 0, 0, 0, time.UTC),
+				).Return([]*models.Invoice{
+					{
+						GUID:              "guid1",
+						CompanyGUID:       "company_guid1",
+						CustomerGUID:      "customer_guid1",
+						PublishDate:       time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC),
+						Payment:           10000,
+						CommissionTax:     400,
+						CommissionTaxRate: 0.04,
+						ConsumptionTax:    40,
+						TaxRate:           0.10,
+						BillingAmount:     10440,
+						PaymentDate:       time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC),
+						Status:            models.InvoiceStatusPaied,
+					},
+					{
+						GUID:              "guid2",
+						CompanyGUID:       "company_guid2",
+						CustomerGUID:      "customer_guid2",
+						PublishDate:       time.Date(2024, 4, 2, 0, 0, 0, 0, time.UTC),
+						Payment:           10000,
+						CommissionTax:     400,
+						CommissionTaxRate: 0.04,
+						ConsumptionTax:    40,
+						TaxRate:           0.10,
+						BillingAmount:     10440,
+						PaymentDate:       time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC),
+						Status:            models.InvoiceStatusUnprocessed,
+					},
+					{
+						GUID:              "guid3",
+						CompanyGUID:       "company_guid3",
+						CustomerGUID:      "customer_guid3",
+						PublishDate:       time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC),
+						Payment:           10000,
+						CommissionTax:     400,
+						CommissionTaxRate: 0.04,
+						ConsumptionTax:    40,
+						TaxRate:           0.10,
+						BillingAmount:     10440,
+						PaymentDate:       time.Date(2024, 4, 5, 0, 0, 0, 0, time.UTC),
+						Status:            models.InvoiceStatusError,
+					},
+				}, nil)
+			},
+			want: want{
+				res: []*server.InvoiceResponse{
+					{
+						GUID:              "guid1",
+						CompanyGUID:       "company_guid1",
+						CustomerGUID:      "customer_guid1",
+						PublishDate:       time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC),
+						Payment:           10000,
+						CommissionTax:     400,
+						CommissionTaxRate: 0.04,
+						ConsumptionTax:    40,
+						TaxRate:           0.10,
+						BillingAmount:     10440,
+						PaymentDate:       time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC),
+						Status:            string(models.InvoiceStatusPaied),
+					},
+					{
+						GUID:              "guid2",
+						CompanyGUID:       "company_guid2",
+						CustomerGUID:      "customer_guid2",
+						PublishDate:       time.Date(2024, 4, 2, 0, 0, 0, 0, time.UTC),
+						Payment:           10000,
+						CommissionTax:     400,
+						CommissionTaxRate: 0.04,
+						ConsumptionTax:    40,
+						TaxRate:           0.10,
+						BillingAmount:     10440,
+						PaymentDate:       time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC),
+						Status:            string(models.InvoiceStatusUnprocessed),
+					},
+					{
+						GUID:              "guid3",
+						CompanyGUID:       "company_guid3",
+						CustomerGUID:      "customer_guid3",
+						PublishDate:       time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC),
+						Payment:           10000,
+						CommissionTax:     400,
+						CommissionTaxRate: 0.04,
+						ConsumptionTax:    40,
+						TaxRate:           0.10,
+						BillingAmount:     10440,
+						PaymentDate:       time.Date(2024, 4, 5, 0, 0, 0, 0, time.UTC),
+						Status:            string(models.InvoiceStatusError),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+
+			mockInvoiceUsecase := mock_usecase.NewMockInvoiceUsecase(ctrl)
+			tt.setup(mockInvoiceUsecase)
+			server := server.NewServer(mockInvoiceUsecase, &server.ServerConfig{})
+			res, err := server.ListInvoice(tt.args)
 			if err != nil {
 				assert.Equal(t, tt.want.err, err)
 			}

--- a/server/mock/mock_usecase/usecase.go
+++ b/server/mock/mock_usecase/usecase.go
@@ -50,3 +50,18 @@ func (mr *MockInvoiceUsecaseMockRecorder) Create(ctx, companyGUID, CustomerGUID,
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockInvoiceUsecase)(nil).Create), ctx, companyGUID, CustomerGUID, publishDate, payment, commissionTaxRate, taxRate, paymentDate)
 }
+
+// List mocks base method.
+func (m *MockInvoiceUsecase) List(ctx context.Context, companyGUID string, firstPaymentDate, lastPaymentDate time.Time) ([]*models.Invoice, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List", ctx, companyGUID, firstPaymentDate, lastPaymentDate)
+	ret0, _ := ret[0].([]*models.Invoice)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// List indicates an expected call of List.
+func (mr *MockInvoiceUsecaseMockRecorder) List(ctx, companyGUID, firstPaymentDate, lastPaymentDate interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockInvoiceUsecase)(nil).List), ctx, companyGUID, firstPaymentDate, lastPaymentDate)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -38,7 +38,12 @@ func (s *Server) Listen() error {
 	})
 
 	router.GET("/api/invoices", func(c *gin.Context) {
-		c.String(http.StatusOK, "")
+		res, err := s.ListInvoice(c)
+		if err != nil {
+			c.String(http.StatusInternalServerError, err.Error())
+			return
+		}
+		c.JSON(http.StatusOK, res)
 	})
 
 	router.GET("/health", func(c *gin.Context) {

--- a/server/usecase.go
+++ b/server/usecase.go
@@ -10,6 +10,5 @@ import (
 
 type InvoiceUsecase interface {
 	Create(ctx context.Context, companyGUID, CustomerGUID string, publishDate time.Time, payment uint64, commissionTaxRate float64, taxRate float64, paymentDate time.Time) (*models.Invoice, error)
-	// 未実装なのでコメントアウト
-	// List(ctx context.Context, companyGUID string, firstPaymentDate, lastPaymentDate time.Time) ([]*models.Invoice, error)
+	List(ctx context.Context, companyGUID string, firstPaymentDate, lastPaymentDate time.Time) ([]*models.Invoice, error)
 }


### PR DESCRIPTION
### 動作確認
```
curl -X GET -d '{"company_guid":"9bsv0s270r00030b23u0","first_payment_date":"2024-04-01T17:44:13Z","last_payment_date":"2024-04-08T17:44:13Z"}'  localhost:8080/api/invoices
[{"guid":"co9v46gn1e47a9abtbg0","company_guid":"9bsv0s270r00030b23u0","customer_guid":"9bsv0s6m409g02pr4mug","publish_date":"2024-04-07T17:44:13Z","payment":10000,"commission_tax":4000,"commission_tax_rate":0.4,"consumption_tax":40,"tax_rate":0.01,"billing_amount":14040,"payment_date":"2024-04-07T17:44:13Z","status":"unprocessed"}]%   
```

### 懸念
GETにBody持たせるのは違和感あるからパラメーターにするか
認証情報からcompany_guidをひく、等の機能が先に必要になると思うのでこのままで
