### PR TITLE
GETにbodyを含めない

### DIFF
--- a/server/invoice_test.go
+++ b/server/invoice_test.go
@@ -180,8 +180,7 @@ func TestListInvoice(t *testing.T) {
 			description: "正常系",
 			args: func() args {
 				ginContext, _ := gin.CreateTestContext(httptest.NewRecorder())
-				body := bytes.NewBufferString("{\"company_guid\": \"company_guid\",\"first_payment_date\": \"2024-04-01T00:00:00Z\",\"last_payment_date\": \"2024-04-05T00:00:00Z\"}")
-				req, _ := http.NewRequest("GET", "/api/invoices", body)
+				req, _ := http.NewRequest("GET", "/api/invoices?first_payment_date=2024-04-01T00:00:00Z&last_payment_date=2024-04-05T00:00:00Z", nil)
 				ginContext.Request = req
 				return args{
 					ginContext,
@@ -290,8 +289,7 @@ func TestListInvoice(t *testing.T) {
 			description: "不正なリクエスト",
 			args: func() args {
 				ginContext, _ := gin.CreateTestContext(httptest.NewRecorder())
-				body := bytes.NewBufferString("{\"invalid\": \"invalid\"}")
-				req, _ := http.NewRequest("GET", "/api/invoices", body)
+				req, _ := http.NewRequest("GET", "/api/invoices?invalid=invalid", nil)
 				ginContext.Request = req
 				return args{
 					ginContext,
@@ -307,8 +305,7 @@ func TestListInvoice(t *testing.T) {
 			description: "Usecase.Listからエラーが返ってくる",
 			args: func() args {
 				ginContext, _ := gin.CreateTestContext(httptest.NewRecorder())
-				body := bytes.NewBufferString("{\"company_guid\": \"company_guid\",\"first_payment_date\": \"2024-04-01T00:00:00Z\",\"last_payment_date\": \"2024-04-05T00:00:00Z\"}")
-				req, _ := http.NewRequest("GET", "/api/invoices", body)
+				req, _ := http.NewRequest("GET", "/api/invoices?first_payment_date=2024-04-01T00:00:00Z&last_payment_date=2024-04-05T00:00:00Z", nil)
 				ginContext.Request = req
 				return args{
 					ginContext,


### PR DESCRIPTION
### 目的
GET時のbodyを含める実装は設計としてはありだがフロントエンド等の使用するフレームワークによっては実装が難しくなる。
これ以上パラメーターが増える検索機能のようなものがつくのならこのままでいいが今は一般的であるクエリパラメーターでもたす形に変更する。
### 動作確認
```
curl -b cookie.txt 'localhost:8080/api/invoices?first_payment_date=2024-04-01T00:00:00Z&last_payment_date=2024-04-05T00:00:00Z' 
[{"guid":"invoice-2","company_guid":"company-1","customer_guid":"customer-1","publish_date":"2024-04-01T00:00:00Z","payment":100000,"commission_tax":1000,"commission_tax_rate":0.01,"consumption_tax":1000,"tax_rate":0.01,"billing_amount":102000,"payment_date":"2024-04-02T00:00:00Z","status":"processing"}]% 
```